### PR TITLE
Asserts declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Asserts for `publishDate` and `unpublishDate` moved from the trait to a YAML validation file
+
 ## [1.0.0] - 2023-01-18
 
 ### Added

--- a/Doctrine/Model/PublishableTrait.php
+++ b/Doctrine/Model/PublishableTrait.php
@@ -3,36 +3,21 @@
 namespace Umanit\ContentPublicationBundle\Doctrine\Model;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 trait PublishableTrait
 {
     /**
      * @var \DateTime|null
      * @ORM\Column(type="datetime", name="publish_date", nullable=true)
-     * @Assert\NotBlank()
-     * @Assert\DateTime()
      */
     #[ORM\Column(name: 'publish_date', type: 'datetime', nullable: true)]
-    #[Assert\NotBlank]
-    #[Assert\DateTime]
     protected ?\DateTimeInterface $publishDate;
 
     /**
      * @var \DateTime|null
      * @ORM\Column(type="datetime", name="unpublish_date", nullable=true)
-     * @Assert\DateTime()
-     * @Assert\Expression(
-     *     expression="this.getUnpublishDate() == null or this.getUnpublishDate() > this.getPublishDate()",
-     *     message="The unpublish date must be greater than the publish date"
-     * )
      */
     #[ORM\Column(name: 'unpublish_date', type: 'datetime', nullable: true)]
-    #[Assert\Expression(
-        expression: 'this.getUnpublishDate() == null or this.getUnpublishDate() > this.getPublishDate()',
-        message: 'The unpublish date must be greater than the publish date'
-    )]
-    #[Assert\DateTime]
     protected ?\DateTimeInterface $unpublishDate;
 
     public function __construct()

--- a/Resources/config/validation.yaml
+++ b/Resources/config/validation.yaml
@@ -1,0 +1,10 @@
+Umanit\ContentPublicationBundle\Doctrine\Model\PublishableInterface:
+    properties:
+        publishDate:
+            -   NotBlank: ~
+            -   DateTime: ~
+        unpublishDate:
+            -   Expression:
+                - expression: 'this.getUnpublishDate() == null or this.getUnpublishDate() > this.getPublishDate()'
+                - message: 'The unpublish date must be greater than the publish date'
+            -   DateTime: ~


### PR DESCRIPTION
- Moves asserts from the trait to a YAML validator file, to avoid double declaration and not have to choose between annotations (#oldschool) and attributes (which whould make them incompatible with PHP < 8)