### PR TITLE
Asserts as annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Asserts as attributes are removed from the trait, to avoid double declaration and still
+  provide PHP 7.4 support
+
 ## [1.0.0] - 2023-01-18
 
 ### Added

--- a/Doctrine/Model/PublishableTrait.php
+++ b/Doctrine/Model/PublishableTrait.php
@@ -14,8 +14,6 @@ trait PublishableTrait
      * @Assert\DateTime()
      */
     #[ORM\Column(name: 'publish_date', type: 'datetime', nullable: true)]
-    #[Assert\NotBlank]
-    #[Assert\DateTime]
     protected ?\DateTimeInterface $publishDate;
 
     /**
@@ -28,11 +26,6 @@ trait PublishableTrait
      * )
      */
     #[ORM\Column(name: 'unpublish_date', type: 'datetime', nullable: true)]
-    #[Assert\Expression(
-        expression: 'this.getUnpublishDate() == null or this.getUnpublishDate() > this.getPublishDate()',
-        message: 'The unpublish date must be greater than the publish date'
-    )]
-    #[Assert\DateTime]
     protected ?\DateTimeInterface $unpublishDate;
 
     public function __construct()


### PR DESCRIPTION
- Removes double declaration of asserts on trait properties in favour of annotations only, to provide support for PHP 7.4