### PR TITLE
fix: redundant assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removes DateTime assertion from `PublishableTrait` as strong typecasting made it redundant
+
 ## [1.0.1] - 2023-02-02
 
 ### Removed

--- a/Doctrine/Model/PublishableTrait.php
+++ b/Doctrine/Model/PublishableTrait.php
@@ -11,7 +11,6 @@ trait PublishableTrait
      * @var \DateTime|null
      * @ORM\Column(type="datetime", name="publish_date", nullable=true)
      * @Assert\NotBlank()
-     * @Assert\DateTime()
      */
     #[ORM\Column(name: 'publish_date', type: 'datetime', nullable: true)]
     protected ?\DateTimeInterface $publishDate;
@@ -19,7 +18,6 @@ trait PublishableTrait
     /**
      * @var \DateTime|null
      * @ORM\Column(type="datetime", name="unpublish_date", nullable=true)
-     * @Assert\DateTime()
      * @Assert\Expression(
      *     expression="this.getUnpublishDate() == null or this.getUnpublishDate() > this.getPublishDate()",
      *     message="The unpublish date must be greater than the publish date"


### PR DESCRIPTION
- Removes DateTime assertion from `PublishableTrait` as strong typecasting made it redundant